### PR TITLE
Year ranges for papers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .env
+.venv
+.streamlit


### PR DESCRIPTION
The scholar can now select year ranges to filter out the papers and get recent papers.

- Due to the selection of the first 5 papers from the top `for i in range(5):  # Get the top 5 results for each field`, scholars will get minimum papers because it is not necessary that scholars will always get results from recent years, it may be different.

- To solve this, use a counter to count the papers; when the required range is collected, then display the papers.

![image](https://github.com/user-attachments/assets/f271cc36-79f8-4e0a-9733-f1c08e1a18b8)
...
- The dates will be entered by the scholar, or it can be increased or decreased using the plus or minus button.

- Here `publication_year = 9999`, if the parsing is failed, the `publication_year` can be set to future years, make sure to change it accordingly.

### Results:
![image](https://github.com/user-attachments/assets/32c21d8b-c00b-42b6-a70b-55f740f0ed1c)
![image](https://github.com/user-attachments/assets/0efa7b6c-f064-4267-b5ee-4e5e5e1ac170)
![image](https://github.com/user-attachments/assets/09e3b61f-cc3d-4d6e-afad-5cb0775b0752)
